### PR TITLE
Raise Telegram message limit and split long messages

### DIFF
--- a/Telegram/SourceFiles/apiwrap.cpp
+++ b/Telegram/SourceFiles/apiwrap.cpp
@@ -3725,8 +3725,8 @@ void ApiWrap::sendMessage(MessageToSend &&message) {
 
 	const auto exactWebPage = !message.webPage.url.isEmpty();
 	auto isFirst = true;
-	while (TextUtilities::CutPart(sending, left, MaxMessageSize)
-		|| (isFirst && exactWebPage)) {
+while (TextUtilities::CutPart(sending, left, MaxMessageBatch)
+|| (isFirst && exactWebPage)) {
 		TextUtilities::Trim(left);
 		const auto isLast = left.empty();
 

--- a/Telegram/SourceFiles/boxes/send_files_box.cpp
+++ b/Telegram/SourceFiles/boxes/send_files_box.cpp
@@ -65,7 +65,8 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 
 namespace {
 
-constexpr auto kMaxMessageLength = 4096;
+// Allow composing long captions up to the global message limit.
+constexpr auto kMaxMessageLength = MaxMessageSize;
 
 using Ui::SendFilesWay;
 

--- a/Telegram/SourceFiles/config.h
+++ b/Telegram/SourceFiles/config.h
@@ -25,7 +25,10 @@ enum {
 
 	SearchPeopleLimit = 5,
 
-	MaxMessageSize = 4096,
+// Maximum allowed message size in characters for composing locally.
+MaxMessageSize = 120000,
+// Maximum message size per batch when sending to the server.
+MaxMessageBatch = 4096,
 
 	WebPageUserId = 701000,
 

--- a/Telegram/SourceFiles/data/data_session.cpp
+++ b/Telegram/SourceFiles/data/data_session.cpp
@@ -4587,7 +4587,7 @@ void Session::insertCheckedServiceNotification(
 	const auto localFlags = MessageFlag::ClientSideUnread
 		| MessageFlag::Local;
 	auto sending = TextWithEntities(), left = message;
-	while (TextUtilities::CutPart(sending, left, MaxMessageSize)) {
+while (TextUtilities::CutPart(sending, left, MaxMessageBatch)) {
 		const auto id = nextLocalMessageId();
 		addNewMessage(
 			id,

--- a/Telegram/SourceFiles/history/history.cpp
+++ b/Telegram/SourceFiles/history/history.cpp
@@ -91,11 +91,8 @@ History::History(not_null<Data::Session*> owner, PeerId peerId)
 , _sendActionPainter(this) {
 	Thread::setMuted(owner->notifySettings().isMuted(peer));
 
-	if (const auto user = peer->asUser()) {
-		if (user->isBot()) {
-			_outboxReadBefore = std::numeric_limits<MsgId>::max();
-		}
-	}
+// Bots should be treated like regular participants and
+// should not mark all outgoing messages as read automatically.
 }
 
 History::~History() = default;


### PR DESCRIPTION
## Summary
- allow composing up to 120k characters per message and batch send in 4k chunks
- permit long captions for file sends
- treat bots like ordinary users by avoiding auto-read shortcuts

## Testing
- `ctest` *(fails: No test configuration file found)*
- `clang-format -n Telegram/SourceFiles/config.h Telegram/SourceFiles/boxes/send_files_box.cpp Telegram/SourceFiles/apiwrap.cpp Telegram/SourceFiles/data/data_session.cpp Telegram/SourceFiles/history/history.cpp` *(warnings about formatting)*

------
https://chatgpt.com/codex/tasks/task_e_68966a3dda4083298bfff0e6fb1dfce6