### PR TITLE
Add thread-safe SettingsManager for auto update

### DIFF
--- a/Telegram/SourceFiles/core/update_checker.cpp
+++ b/Telegram/SourceFiles/core/update_checker.cpp
@@ -16,6 +16,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "storage/localstorage.h"
 #include "core/application.h"
 #include "core/changelogs.h"
+#include "settings/settings_manager.h"
 #include "core/click_handler_types.h"
 #include "mainwindow.h"
 #include "main/main_account.h"
@@ -1244,7 +1245,7 @@ void Updater::start(bool forceWait) {
 	}
 
 	_timer.cancel();
-	if (!cAutoUpdate() || _action != Action::Waiting) {
+	if (!SettingsManager::instance().autoUpdate() || _action != Action::Waiting) {
 		return;
 	}
 
@@ -1649,7 +1650,7 @@ void UpdateApplication() {
 		}();
 		UrlClickHandler::Open(url);
 	} else {
-		cSetAutoUpdate(true);
+		SettingsManager::instance().setAutoUpdate(true);
 		const auto window = Core::IsAppLaunched()
 			? Core::App().activePrimaryWindow()
 			: nullptr;

--- a/Telegram/SourceFiles/settings.cpp
+++ b/Telegram/SourceFiles/settings.cpp
@@ -29,7 +29,6 @@ bool gStartMinimized = false;
 bool gStartInTray = false;
 bool gAutoStart = false;
 bool gSendToMenu = false;
-bool gAutoUpdate = true;
 LaunchMode gLaunchMode = LaunchModeNormal;
 bool gSeenTrayTooltip = false;
 bool gRestartingUpdate = false, gRestarting = false, gRestartingToSettings = false, gWriteProtected = false;

--- a/Telegram/SourceFiles/settings.h
+++ b/Telegram/SourceFiles/settings.h
@@ -69,7 +69,6 @@ inline QString cDialogHelperPathFinal() {
 	return cDialogHelperPath().isEmpty() ? cExeDir() : cDialogHelperPath();
 }
 
-DeclareSetting(bool, AutoUpdate);
 
 DeclareSetting(bool, SeenTrayTooltip);
 DeclareSetting(bool, RestartingUpdate);

--- a/Telegram/SourceFiles/settings/settings_advanced.cpp
+++ b/Telegram/SourceFiles/settings/settings_advanced.cpp
@@ -6,6 +6,7 @@ For license and copyright information please follow this link:
 https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 */
 #include "settings/settings_advanced.h"
+#include "settings_manager.h"
 
 #include "api/api_global_privacy.h"
 #include "apiwrap.h"
@@ -187,16 +188,16 @@ void SetupUpdate(not_null<Ui::VerticalLayout*> container) {
 		}
 	};
 
-	toggle->toggleOn(rpl::single(cAutoUpdate()));
+	toggle->toggleOn(rpl::single(SettingsManager::instance().autoUpdate()));
 	toggle->toggledValue(
 	) | rpl::filter([](bool toggled) {
-		return (toggled != cAutoUpdate());
+		return (toggled != SettingsManager::instance().autoUpdate());
 	}) | rpl::start_with_next([=](bool toggled) {
-		cSetAutoUpdate(toggled);
+		SettingsManager::instance().setAutoUpdate(toggled);
 
 		Local::writeSettings();
 		Core::UpdateChecker checker;
-		if (cAutoUpdate()) {
+		if (SettingsManager::instance().autoUpdate()) {
 			checker.start();
 		} else {
 			checker.stop();
@@ -998,7 +999,7 @@ void Advanced::setupContent(not_null<Window::SessionController*> controller) {
 			AddSkip(content);
 		}
 	};
-	if (!cAutoUpdate()) {
+	if (!SettingsManager::instance().autoUpdate()) {
 		addUpdate();
 	}
 	addDivider();
@@ -1022,7 +1023,7 @@ void Advanced::setupContent(not_null<Window::SessionController*> controller) {
 		AddSkip(content);
 	}
 
-	if (cAutoUpdate()) {
+	if (SettingsManager::instance().autoUpdate()) {
 		addUpdate();
 	}
 

--- a/Telegram/SourceFiles/settings/settings_manager.cpp
+++ b/Telegram/SourceFiles/settings/settings_manager.cpp
@@ -1,0 +1,33 @@
+#include "settings_manager.h"
+
+#include <QtCore/QDataStream>
+
+SettingsManager &SettingsManager::instance() {
+    static SettingsManager manager;
+    return manager;
+}
+
+bool SettingsManager::autoUpdate() const {
+    QMutexLocker lock(&_mutex);
+    return _autoUpdate;
+}
+
+void SettingsManager::setAutoUpdate(bool value) {
+    QMutexLocker lock(&_mutex);
+    _autoUpdate = value;
+}
+
+QByteArray SettingsManager::serialize() const {
+    QMutexLocker lock(&_mutex);
+    QByteArray result;
+    QDataStream stream(&result, QIODevice::WriteOnly);
+    stream << _autoUpdate;
+    return result;
+}
+
+void SettingsManager::deserialize(const QByteArray &data) {
+    QMutexLocker lock(&_mutex);
+    QDataStream stream(data);
+    stream >> _autoUpdate;
+}
+

--- a/Telegram/SourceFiles/settings/settings_manager.h
+++ b/Telegram/SourceFiles/settings/settings_manager.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QtCore/QMutex>
+#include <QtCore/QByteArray>
+
+class SettingsManager {
+public:
+    static SettingsManager &instance();
+
+    bool autoUpdate() const;
+    void setAutoUpdate(bool value);
+
+    QByteArray serialize() const;
+    void deserialize(const QByteArray &data);
+
+private:
+    SettingsManager() = default;
+
+    mutable QMutex _mutex;
+    bool _autoUpdate = true;
+};
+

--- a/Telegram/SourceFiles/storage/details/storage_settings_scheme.cpp
+++ b/Telegram/SourceFiles/storage/details/storage_settings_scheme.cpp
@@ -13,6 +13,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "storage/storage_media_prepare.h"
 #include "core/application.h"
 #include "core/core_settings.h"
+#include "settings/settings_manager.h"
 #include "mtproto/mtproto_config.h"
 #include "ui/widgets/fields/input_field.h"
 #include "ui/chat/attach/attach_send_files_way.h"
@@ -686,8 +687,8 @@ bool ReadSetting(
 		stream >> v;
 		if (!CheckStreamStatus(stream)) return false;
 
-		cSetAutoUpdate(v == 1);
-		if (!Core::UpdaterDisabled() && !cAutoUpdate()) {
+		SettingsManager::instance().setAutoUpdate(v == 1);
+		if (!Core::UpdaterDisabled() && !SettingsManager::instance().autoUpdate()) {
 			Core::UpdateChecker().stop();
 		}
 	} break;

--- a/Telegram/SourceFiles/storage/localstorage.cpp
+++ b/Telegram/SourceFiles/storage/localstorage.cpp
@@ -21,6 +21,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "core/file_location.h"
 #include "core/application.h"
 #include "core/core_settings.h"
+#include "settings/settings_manager.h"
 #include "media/audio/media_audio.h"
 #include "mtproto/mtproto_config.h"
 #include "mtproto/mtproto_dc_options.h"
@@ -480,7 +481,7 @@ void writeSettings() {
 	data.stream << quint32(dbiStartMinimized) << qint32(cStartMinimized());
 	data.stream << quint32(dbiSendToMenu) << qint32(cSendToMenu());
 	data.stream << quint32(dbiSeenTrayTooltip) << qint32(cSeenTrayTooltip());
-	data.stream << quint32(dbiAutoUpdate) << qint32(cAutoUpdate());
+	data.stream << quint32(dbiAutoUpdate) << qint32(SettingsManager::instance().autoUpdate());
 	data.stream << quint32(dbiLastUpdateCheck) << qint32(cLastUpdateCheck());
 	data.stream << quint32(dbiScalePercent) << qint32(cConfigScale());
 	data.stream << quint32(dbiFallbackProductionConfig) << configSerialized;
@@ -569,7 +570,7 @@ void writeAutoupdatePrefix(const QString &prefix) {
 			f.write(prefix.toUtf8());
 			f.close();
 		}
-		if (cAutoUpdate()) {
+		if (SettingsManager::instance().autoUpdate()) {
 			Core::UpdateChecker checker;
 			checker.start();
 		}

--- a/tests/settings_manager_test.cpp
+++ b/tests/settings_manager_test.cpp
@@ -1,0 +1,12 @@
+#include "../Telegram/SourceFiles/settings/settings_manager.h"
+#include <cassert>
+
+int main() {
+    auto &manager = SettingsManager::instance();
+    manager.setAutoUpdate(true);
+    auto data = manager.serialize();
+    manager.setAutoUpdate(false);
+    manager.deserialize(data);
+    assert(manager.autoUpdate() == true);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Introduce thread-safe `SettingsManager` handling the auto-update flag
- Replace legacy `cAutoUpdate` uses with `SettingsManager` methods
- Add serialization/deserialization test for `SettingsManager`

## Testing
- `clang-format -n Telegram/SourceFiles/settings/settings_manager.h Telegram/SourceFiles/settings/settings_manager.cpp Telegram/SourceFiles/settings.cpp Telegram/SourceFiles/settings.h Telegram/SourceFiles/storage/localstorage.cpp Telegram/SourceFiles/storage/details/storage_settings_scheme.cpp Telegram/SourceFiles/settings/settings_advanced.cpp Telegram/SourceFiles/core/update_checker.cpp tests/settings_manager_test.cpp`
- `g++ -fPIC tests/settings_manager_test.cpp Telegram/SourceFiles/settings/settings_manager.cpp -I. -I Telegram/SourceFiles $(pkg-config --cflags --libs Qt5Core) -o tests/settings_manager_test`
- `./tests/settings_manager_test`


------
https://chatgpt.com/codex/tasks/task_e_6896731cf8cc8329a3fafac6ee4025c3