### PR TITLE
Update screen scale when monitors change

### DIFF
--- a/Telegram/SourceFiles/settings.cpp
+++ b/Telegram/SourceFiles/settings.cpp
@@ -56,9 +56,6 @@ bool gPasswordRecovered = false;
 int32 gPasscodeBadTries = 0;
 crl::time gPasscodeLastTry = 0;
 
-float64 gRetinaFactor = 1.;
-int32 gIntRetinaFactor = 1;
-
 int gOtherOnline = 0;
 
 int32 gAutoDownloadPhoto = 0; // all auto download


### PR DESCRIPTION
## Summary
- derive device pixel ratio from the primary screen
- refresh scale when screens are added, removed or switched
- drop unused gRetinaFactor/gIntRetinaFactor globals

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file)*
- `cmake --build build --target test` *(fails: could not find CMAKE_PROJECT_NAME in Cache)*

------
https://chatgpt.com/codex/tasks/task_e_6896734000f08329bb8f602df1a1697c