### PR TITLE
Offload sticker archive toast to UI thread

### DIFF
--- a/Telegram/SourceFiles/data/stickers/data_stickers.cpp
+++ b/Telegram/SourceFiles/data/stickers/data_stickers.cpp
@@ -394,11 +394,12 @@ void Stickers::applyArchivedResult(
 		session().local().writeArchivedMasks();
 	}
 
-	// TODO async toast.
-	Ui::Toast::Show(Ui::Toast::Config{
-		.text = { tr::lng_stickers_packs_archived(tr::now) },
-		.st = &st::stickersToast,
-	});
+        crl::on_main([] {
+                Ui::Toast::Show(Ui::Toast::Config{
+                        .text = { tr::lng_stickers_packs_archived(tr::now) },
+                        .st = &st::stickersToast,
+                });
+        });
 	//Ui::show(
 	//	Box<StickersBox>(archived, &session()),
 	//	Ui::LayerOption::KeepOther);

--- a/tests/ui_responsiveness_test.cpp
+++ b/tests/ui_responsiveness_test.cpp
@@ -1,0 +1,10 @@
+#include "crl/crl.h"
+#include <atomic>
+#include <cassert>
+
+int main() {
+    std::atomic_bool called = false;
+    crl::on_main([&] { called = true; });
+    assert(!called.load());
+    return 0;
+}


### PR DESCRIPTION
## Summary
- dispatch sticker archive toast creation via `crl::on_main` so the call returns immediately
- add a simple UI responsiveness test to ensure `crl::on_main` queues work

## Testing
- `clang-format --dry-run Telegram/SourceFiles/data/stickers/data_stickers.cpp tests/ui_responsiveness_test.cpp`
- `g++ -std=c++17 tests/settings_manager_test.cpp -I./ -o build/test/settings_manager_test && ./build/test/settings_manager_test` *(fails: QtCore/QMutex: No such file or directory)*
- `g++ -std=c++17 tests/ui_responsiveness_test.cpp -I./ -o build/test/ui_responsiveness_test && ./build/test/ui_responsiveness_test` *(fails: crl/crl.h: No such file or directory)*
- `python -m pytest tests/test_color_contrast.py`

------
https://chatgpt.com/codex/tasks/task_e_689677505a2c83298cc6501c8d1aa250