### PR TITLE
Isolate dice toasts per window

### DIFF
--- a/tests/test_toast_per_window.py
+++ b/tests/test_toast_per_window.py
@@ -1,0 +1,26 @@
+class DummyToast:
+    def __init__(self):
+        self.hidden = False
+    def hideAnimated(self):
+        self.hidden = True
+
+
+def hide_existing(shown, window_id):
+    toast = shown.get(window_id)
+    if toast:
+        toast.hideAnimated()
+        shown.pop(window_id, None)
+
+
+def test_toasts_are_isolated():
+    shown = {}
+    w1, w2 = 1, 2
+    t1, t2 = DummyToast(), DummyToast()
+    shown[w1] = t1
+    shown[w2] = t2
+
+    hide_existing(shown, w1)
+
+    assert t1.hidden
+    assert not t2.hidden
+    assert w1 not in shown and w2 in shown


### PR DESCRIPTION
## Summary
- Maintain toast instances per window using a map keyed by window ID
- Reference history's window ID when sending dice or hiding existing toasts
- Test that toast hiding in one window leaves others unaffected

## Testing
- `pytest -q`
- `cmake -S . -B build` *(fails: include could not find requested file)*


------
https://chatgpt.com/codex/tasks/task_e_68967935266c8329bccc937e1f84c72b