### PR TITLE
Handle multiple usernames across API and UI

### DIFF
--- a/Telegram/SourceFiles/api/api_updates.cpp
+++ b/Telegram/SourceFiles/api/api_updates.cpp
@@ -1820,33 +1820,34 @@ void Updates::feedUpdate(const MTPUpdate &update) {
 	case mtpc_updateWebPage: {
 		auto &d = update.c_updateWebPage();
 
-		// Update web page anyway.
-		session().data().processWebpage(d.vwebpage());
-		session().data().sendWebPageGamePollNotifications();
+                // Update web page anyway.
+                session().data().processWebpage(d.vwebpage());
+                session().data().sendWebPageGamePollNotifications();
 
-		updateAndApply(d.vpts().v, d.vpts_count().v, update);
-	} break;
+                updateAndApply(d.vpts().v, d.vpts_count().v, update);
+        } break;
 
-	case mtpc_updateChannelWebPage: {
-		auto &d = update.c_updateChannelWebPage();
+        case mtpc_updateChannelWebPage: {
+          auto &d = update.c_updateChannelWebPage();
 
-		// Update web page anyway.
-		session().data().processWebpage(d.vwebpage());
-		session().data().sendWebPageGamePollNotifications();
+          // Update web page anyway.
+          session().data().processWebpage(d.vwebpage());
+          session().data().sendWebPageGamePollNotifications();
 
-		auto channel = session().data().channelLoaded(d.vchannel_id());
-		if (channel && !_handlingChannelDifference) {
-			if (channel->ptsRequesting()) { // skip global updates while getting channel difference
-				return;
-			} else {
-				channel->ptsUpdateAndApply(d.vpts().v, d.vpts_count().v, update);
-			}
-		} else {
-			applyUpdateNoPtsCheck(update);
-		}
-	} break;
+          auto channel = session().data().channelLoaded(d.vchannel_id());
+          if (channel && !_handlingChannelDifference) {
+            if (channel->ptsRequesting()) { // skip global updates while getting
+                                            // channel difference
+              return;
+            } else {
+              channel->ptsUpdateAndApply(d.vpts().v, d.vpts_count().v, update);
+            }
+          } else {
+            applyUpdateNoPtsCheck(update);
+          }
+        } break;
 
-	case mtpc_updateMessagePoll: {
+        case mtpc_updateMessagePoll: {
 		session().data().applyUpdate(update.c_updateMessagePoll());
 	} break;
 
@@ -1930,18 +1931,22 @@ void Updates::feedUpdate(const MTPUpdate &update) {
 				? user->firstName
 				: qs(d.vfirst_name());
 			const auto last = contact ? user->lastName : qs(d.vlast_name());
-			// #TODO usernames
-			const auto username = d.vusernames().v.isEmpty()
-				? QString()
-				: qs(d.vusernames().v.front().data().vusername());
-			user->setName(
-				TextUtilities::SingleLine(first),
-				TextUtilities::SingleLine(last),
-				user->nameOrPhone,
-				TextUtilities::SingleLine(username));
-			user->setUsernames(Api::Usernames::FromTL(d.vusernames()));
-		}
-	} break;
+                       auto usernames = std::vector<QString>();
+                       usernames.reserve(d.vusernames().v.size());
+                       for (const auto &entry : d.vusernames().v) {
+                               usernames.push_back(qs(entry.data().vusername()));
+                       }
+                       const auto username = usernames.empty()
+                               ? QString()
+                               : usernames.front();
+                       user->setName(
+                               TextUtilities::SingleLine(first),
+                               TextUtilities::SingleLine(last),
+                               user->nameOrPhone,
+                               TextUtilities::SingleLine(username));
+                       user->setUsernames(Api::Usernames::FromTL(d.vusernames()));
+               }
+       } break;
 
 	case mtpc_updateUser: {
 		auto &d = update.c_updateUser();

--- a/Telegram/SourceFiles/boxes/peer_list_box.cpp
+++ b/Telegram/SourceFiles/boxes/peer_list_box.cpp
@@ -1675,25 +1675,25 @@ bool PeerListContent::showRowMenu(
 	setContexted(Selected());
 	if (_pressButton != Qt::LeftButton) {
 		mousePressReleased(_pressButton);
-	}
+        }
 
-	if (highlightRow) {
-		row = getRow(index);
-	}
-	if (!row) {
-		return false;
-	}
+        if (highlightRow) {
+          row = getRow(index);
+        }
+        if (!row) {
+          return false;
+        }
 
-	_contextMenu = _controller->rowContextMenu(this, row);
-	const auto raw = _contextMenu.get();
-	if (!raw) {
-		return false;
-	}
+        _contextMenu = _controller->rowContextMenu(this, row);
+        const auto raw = _contextMenu.get();
+        if (!raw) {
+          return false;
+        }
 
-	if (highlightRow) {
-		setContexted({ index, false });
-	}
-	raw->setDestroyedCallback(crl::guard(
+        if (highlightRow) {
+          setContexted({index, false});
+        }
+        raw->setDestroyedCallback(crl::guard(
 		this,
 		[=] {
 			if (highlightRow) {
@@ -1831,34 +1831,40 @@ crl::time PeerListContent::paintRow(
 	p.setPen(anim::pen(st.nameFg, st.nameFgChecked, nameCheckedRatio));
 	name.drawLeftElided(p, namex, namey, namew, width());
 
-	p.setFont(st::contactsStatusFont);
-	if (row->isSearchResult()
-		&& !_mentionHighlight.isEmpty()
-		&& peer
-		&& peer->username().startsWith(
-			_mentionHighlight,
-			Qt::CaseInsensitive)) {
-		const auto username = peer->username();
-		const auto availableWidth = statusw;
-		auto highlightedPart = '@' + username.mid(0, _mentionHighlight.size());
-		auto grayedPart = username.mid(_mentionHighlight.size());
-		const auto highlightedWidth = st::contactsStatusFont->width(highlightedPart);
-		if (highlightedWidth >= availableWidth || grayedPart.isEmpty()) {
-			if (highlightedWidth > availableWidth) {
-				highlightedPart = st::contactsStatusFont->elided(highlightedPart, availableWidth);
-			}
-			p.setPen(st.statusFgActive);
-			p.drawTextLeft(statusx, statusy, width(), highlightedPart);
-		} else {
-			grayedPart = st::contactsStatusFont->elided(grayedPart, availableWidth - highlightedWidth);
-			p.setPen(st.statusFgActive);
-			p.drawTextLeft(statusx, statusy, width(), highlightedPart);
-			p.setPen(selected ? st.statusFgOver : st.statusFg);
-			p.drawTextLeft(statusx + highlightedWidth, statusy, width(), grayedPart);
-		}
-	} else {
-		row->paintStatusText(p, st, statusx, statusy, statusw, width(), selected);
-	}
+       p.setFont(st::contactsStatusFont);
+       if (row->isSearchResult() && !_mentionHighlight.isEmpty() && peer) {
+               const auto &usernames = peer->usernames();
+               auto username = QString();
+               for (const auto &u : usernames) {
+                       if (u.startsWith(_mentionHighlight, Qt::CaseInsensitive)) {
+                               username = u;
+                               break;
+                       }
+               }
+               if (!username.isEmpty()) {
+                       const auto availableWidth = statusw;
+                       auto highlightedPart = '@' + username.mid(0, _mentionHighlight.size());
+                       auto grayedPart = username.mid(_mentionHighlight.size());
+                       const auto highlightedWidth = st::contactsStatusFont->width(highlightedPart);
+                       if (highlightedWidth >= availableWidth || grayedPart.isEmpty()) {
+                               if (highlightedWidth > availableWidth) {
+                                       highlightedPart = st::contactsStatusFont->elided(highlightedPart, availableWidth);
+                               }
+                               p.setPen(st.statusFgActive);
+                               p.drawTextLeft(statusx, statusy, width(), highlightedPart);
+                       } else {
+                               grayedPart = st::contactsStatusFont->elided(grayedPart, availableWidth - highlightedWidth);
+                               p.setPen(st.statusFgActive);
+                               p.drawTextLeft(statusx, statusy, width(), highlightedPart);
+                               p.setPen(selected ? st.statusFgOver : st.statusFg);
+                               p.drawTextLeft(statusx + highlightedWidth, statusy, width(), grayedPart);
+                       }
+               } else {
+                       row->paintStatusText(p, st, statusx, statusy, statusw, width(), selected);
+               }
+       } else {
+               row->paintStatusText(p, st, statusx, statusy, statusw, width(), selected);
+       }
 
 	row->elementsPaint(
 		p,

--- a/Telegram/SourceFiles/data/data_user_names.cpp
+++ b/Telegram/SourceFiles/data/data_user_names.cpp
@@ -38,32 +38,23 @@ void UsernamesInfo::setUsername(const QString &username) {
 }
 
 void UsernamesInfo::setUsernames(const Usernames &usernames) {
-	auto editableUsername = QString();
-	auto newUsernames = ranges::views::all(
-		usernames
-	) | ranges::views::filter([&](const Data::Username &username) {
-		if (username.editable) {
-			editableUsername = username.username;
-			return true;
-		}
-		return username.active;
-	}) | ranges::views::transform([](const Data::Username &username) {
-		return username.username;
-	}) | ranges::to_vector;
+  auto editableIndex = -1;
+  auto newUsernames =
+      ranges::views::all(usernames) |
+      ranges::views::transform(
+          [](const Data::Username &username) { return username.username; }) |
+      ranges::to_vector;
 
-	if (!ranges::equal(_usernames, newUsernames)) {
-		_usernames = std::move(newUsernames);
-	}
-	if (!editableUsername.isEmpty()) {
-		for (auto i = 0; i < _usernames.size(); i++) {
-			if (_usernames[i] == editableUsername) {
-				_indexEditableUsername = i;
-				break;
-			}
-		}
-	} else {
-		_indexEditableUsername = -1;
-	}
+  if (!ranges::equal(_usernames, newUsernames)) {
+    _usernames = std::move(newUsernames);
+  }
+  for (auto i = 0; i < usernames.size(); ++i) {
+    if (usernames[i].editable) {
+      editableIndex = i;
+      break;
+    }
+  }
+  _indexEditableUsername = editableIndex;
 }
 
 QString UsernamesInfo::username() const {

--- a/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
+++ b/Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp
@@ -1069,46 +1069,36 @@ void InnerWidget::paintPeerSearchResult(
 		not_null<const PeerSearchResult*> result,
 		const Ui::PaintContext &context) {
 	QRect fullRect(0, 0, context.width, st::dialogsRowHeight);
-	p.fillRect(
-		fullRect,
-		(context.active
-			? st::dialogsBgActive
-			: context.selected
-			? st::dialogsBgOver
-			: currentBg()));
-	if (!context.active) {
-		result->row.paintRipple(p, 0, 0, context.width);
-	}
+        p.fillRect(fullRect, (context.active     ? st::dialogsBgActive
+                              : context.selected ? st::dialogsBgOver
+                                                 : currentBg()));
+        if (!context.active) {
+          result->row.paintRipple(p, 0, 0, context.width);
+        }
 
-	auto peer = result->peer;
-	auto userpicPeer = (peer->migrateTo() ? peer->migrateTo() : peer);
-	userpicPeer->paintUserpicLeft(
-		p,
-		result->row.userpicView(),
-		context.st->padding.left(),
-		context.st->padding.top(),
-		width(),
-		context.st->photoSize);
+        auto peer = result->peer;
+        auto userpicPeer = (peer->migrateTo() ? peer->migrateTo() : peer);
+        userpicPeer->paintUserpicLeft(
+            p, result->row.userpicView(), context.st->padding.left(),
+            context.st->padding.top(), width(), context.st->photoSize);
 
-	auto nameleft = context.st->nameLeft;
-	auto namewidth = context.width - nameleft - context.st->padding.right();
-	QRect rectForName(nameleft, context.st->nameTop, namewidth, st::semiboldFont->height);
+        auto nameleft = context.st->nameLeft;
+        auto namewidth = context.width - nameleft - context.st->padding.right();
+        QRect rectForName(nameleft, context.st->nameTop, namewidth,
+                          st::semiboldFont->height);
 
-	if (result->name.isEmpty()) {
-		result->name.setText(
-			st::semiboldTextStyle,
-			peer->name(),
-			Ui::NameTextOptions());
-	}
+        if (result->name.isEmpty()) {
+          result->name.setText(st::semiboldTextStyle, peer->name(),
+                               Ui::NameTextOptions());
+        }
 
-	// draw chat icon
-	if (const auto chatTypeIcon = Ui::ChatTypeIcon(peer, context)) {
-		chatTypeIcon->paint(p, rectForName.topLeft(), context.width);
-		rectForName.setLeft(rectForName.left()
-			+ chatTypeIcon->width()
-			+ st::dialogsChatTypeSkip);
-	}
-	const auto badgeWidth = result->badge.drawGetWidth(
+        // draw chat icon
+        if (const auto chatTypeIcon = Ui::ChatTypeIcon(peer, context)) {
+          chatTypeIcon->paint(p, rectForName.topLeft(), context.width);
+          rectForName.setLeft(rectForName.left() + chatTypeIcon->width() +
+                              st::dialogsChatTypeSkip);
+        }
+        const auto badgeWidth = result->badge.drawGetWidth(
 		p,
 		rectForName,
 		result->name.maxWidth(),
@@ -1140,15 +1130,24 @@ void InnerWidget::paintPeerSearchResult(
 		});
 	rectForName.setWidth(rectForName.width() - badgeWidth);
 
-	QRect tr(context.st->textLeft, context.st->textTop, namewidth, st::dialogsTextFont->height);
-	p.setFont(st::dialogsTextFont);
-	QString username = peer->username();
-	if (!context.active && username.startsWith(_peerSearchQuery, Qt::CaseInsensitive)) {
-		auto first = '@' + username.mid(0, _peerSearchQuery.size());
-		auto second = username.mid(_peerSearchQuery.size());
-		auto w = st::dialogsTextFont->width(first);
-		if (w >= tr.width()) {
-			p.setPen(st::dialogsTextFgService);
+       QRect tr(context.st->textLeft, context.st->textTop, namewidth, st::dialogsTextFont->height);
+       p.setFont(st::dialogsTextFont);
+       const auto &usernames = peer->usernames();
+       auto username = usernames.empty() ? QString() : usernames.front();
+       if (!context.active) {
+               for (const auto &u : usernames) {
+                       if (u.startsWith(_peerSearchQuery, Qt::CaseInsensitive)) {
+                               username = u;
+                               break;
+                       }
+               }
+       }
+       if (!context.active && username.startsWith(_peerSearchQuery, Qt::CaseInsensitive)) {
+               auto first = '@' + username.mid(0, _peerSearchQuery.size());
+               auto second = username.mid(_peerSearchQuery.size());
+               auto w = st::dialogsTextFont->width(first);
+               if (w >= tr.width()) {
+                       p.setPen(st::dialogsTextFgService);
 			p.drawText(tr.left(), tr.top() + st::dialogsTextFont->ascent, st::dialogsTextFont->elided(first, tr.width()));
 		} else {
 			p.setPen(st::dialogsTextFgService);

--- a/Telegram/SourceFiles/info/profile/info_profile_values.cpp
+++ b/Telegram/SourceFiles/info/profile/info_profile_values.cpp
@@ -51,13 +51,15 @@ auto PlainAboutValue(not_null<PeerData*> peer) {
 	});
 }
 
-auto PlainUsernameValue(not_null<PeerData*> peer) {
-	return rpl::merge(
-		peer->session().changes().peerFlagsValue(peer, UpdateFlag::Username),
-		peer->session().changes().peerFlagsValue(peer, UpdateFlag::Usernames)
-	) | rpl::map([=] {
-		return peer->username();
-	});
+auto PlainUsernameValue(not_null<PeerData *> peer) {
+  return rpl::merge(peer->session().changes().peerFlagsValue(
+                        peer, UpdateFlag::Username),
+                    peer->session().changes().peerFlagsValue(
+                        peer, UpdateFlag::Usernames)) |
+         rpl::map([=] {
+           const auto &list = peer->usernames();
+           return list.empty() ? QString() : list.front();
+         });
 }
 
 auto PlainPrimaryUsernameValue(not_null<PeerData*> peer) {


### PR DESCRIPTION
## Summary
- collect all usernames from API updates and store them for users
- track editable username and retain complete username list in data layer
- update search and profile UI to use all available usernames

## Testing
- `clang-format -n -lines=1822:1835 Telegram/SourceFiles/api/api_updates.cpp`
- `clang-format -n -lines=40:58 Telegram/SourceFiles/data/data_user_names.cpp`
- `clang-format -n -lines=54:58 Telegram/SourceFiles/info/profile/info_profile_values.cpp`
- `clang-format -n -lines=1078:1100 Telegram/SourceFiles/dialogs/dialogs_inner_widget.cpp`
- `clang-format -n -lines=1678:1694 Telegram/SourceFiles/boxes/peer_list_box.cpp`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689679ae444c8329a98e062a062c0c87